### PR TITLE
Patch Release: 0.3.3

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
+        version: 25.10
 
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NFT_VER: "0.9.3"
+  NFT_VER: "0.9.2"
   NFT_WORKDIR: "~"
   NXF_ANSI_LOG: false
   NXF_SINGULARITY_CACHEDIR: ${{ github.workspace }}/.singularity
@@ -39,7 +39,7 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
           ls -la ./
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
-          max_shards: 4
+          max_shards: 7
 
       - name: debug
         run: |
@@ -76,21 +76,21 @@ jobs:
           - isMain: false
             profile: "singularity"
         NXF_VER:
-          - "24.10.3"
           - "25.10.4"
+          - "24.10.3"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}
 
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
       - name: Run nf-test
         id: run_nf_test
         uses: ./.github/actions/nf-test
-        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }} # Currently not testing latest-everything, but if we do, we don't want it to cause workflow failure
         env:
           NFT_WORKDIR: ${{ env.NFT_WORKDIR }}
           NXF_VERSION: ${{ matrix.NXF_VER }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -77,7 +77,7 @@ jobs:
             profile: "singularity"
         NXF_VER:
           - "24.10.3"
-          - "latest-everything"
+          - "25.10.4"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NFT_VER: "0.9.2"
+  NFT_VER: "0.9.3"
   NFT_WORKDIR: "~"
   NXF_ANSI_LOG: false
   NXF_SINGULARITY_CACHEDIR: ${{ github.workspace }}/.singularity
@@ -39,7 +39,7 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
           ls -la ./
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
-          max_shards: 7
+          max_shards: 4
 
       - name: debug
         run: |
@@ -76,21 +76,21 @@ jobs:
           - isMain: false
             profile: "singularity"
         NXF_VER:
-          - "25.10.4"
           - "24.10.3"
+          - "25.10.4"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Run nf-test
         id: run_nf_test
         uses: ./.github/actions/nf-test
-        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }} # Currently not testing latest-everything, but if we do, we don't want it to cause workflow failure
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }} # Currently not testing latest-everything, but if revert it back, we don't want it to cause workflow failure due issues
         env:
           NFT_WORKDIR: ${{ env.NFT_WORKDIR }}
           NXF_VERSION: ${{ matrix.NXF_VER }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.3] - 2026-05-04
+## [0.3.3] - 2026-05-06
 
 ### `Updated`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### `Updated`
+
+- Set nextflow version 25.10.4 to replace 'latest-everything' to confirm compatibility with next IRIDA-Next nextflow version in `.github/workflows` for nf-test. [PR #39](https://github.com/phac-nml/staramrnf/pull/39)
+
 ## [0.3.2] - 2026-03-13
 
 - Updated staramr to the [patch release](https://github.com/phac-nml/staramr) `0.12.1` which includes updates of CGE databases and gene-drug mapping key for Pointfinder/Resfinder.[PR #37](https://github.com/phac-nml/staramrnf/pull/37)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.3.3] - 2026-05-04
 
 ### `Updated`
 
 - Set nextflow version 25.10.4 to replace 'latest-everything' to confirm compatibility with next IRIDA-Next nextflow version in `.github/workflows` for nf-test. [PR #39](https://github.com/phac-nml/staramrnf/pull/39)
+- starAMR version updated to 0.12.2. [PR #40](https://github.com/phac-nml/staramrnf/pull/40)
 
 ## [0.3.2] - 2026-03-13
 
@@ -64,3 +65,4 @@ staramrnf follows the `nf-core` pipeline file structure and used the nf-core [te
 [0.3.0]: https://github.com/phac-nml/staramrnf/releases/tag/0.3.0
 [0.3.1]: https://github.com/phac-nml/staramrnf/releases/tag/0.3.1
 [0.3.2]: https://github.com/phac-nml/staramrnf/releases/tag/0.3.2
+[0.3.3]: https://github.com/phac-nml/staramrnf/releases/tag/0.3.3

--- a/modules/local/staramr/main.nf
+++ b/modules/local/staramr/main.nf
@@ -4,8 +4,8 @@ process STARAMR_SEARCH {
 
     conda "bioconda::staramr=0.12.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/staramr:0.12.1--pyhdfd78af_1':
-        'biocontainers/staramr:0.12.1--pyhdfd78af_1' }"
+        'https://depot.galaxyproject.org/singularity/staramr:0.12.2--pyhdfd78af_0':
+        'biocontainers/staramr:0.12.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(contigs)

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@
     Default config options for all compute environments
 ----------------------------------------------------------------------------------------
 */
-
+//
 // Global default params, used in configs
 params {
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@
     Default config options for all compute environments
 ----------------------------------------------------------------------------------------
 */
-//
+
 // Global default params, used in configs
 params {
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -237,7 +237,7 @@ manifest {
     description     = """StarAMR: Scans genome contigs against the ResFinder, PlasmidFinder, and PointFinder databases."""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=24.10.3'
-    version         = '0.3.2'
+    version         = '0.3.3'
     doi             = ''
     defaultBranch   = 'main'
 }
@@ -247,8 +247,8 @@ includeConfig 'conf/modules.config'
 
 // Function to ensure that resource requirements don't go beyond
 // a maximum limit
-def check_max(obj, type) {
-    if (type == 'memory') {
+def check_max(obj, val_type) {
+    if (val_type == 'memory') {
         try {
             if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
                 return params.max_memory as nextflow.util.MemoryUnit
@@ -258,7 +258,7 @@ def check_max(obj, type) {
             println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
             return obj
         }
-    } else if (type == 'time') {
+    } else if (val_type == 'time') {
         try {
             if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
                 return params.max_time as nextflow.util.Duration
@@ -268,7 +268,7 @@ def check_max(obj, type) {
             println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
             return obj
         }
-    } else if (type == 'cpus') {
+    } else if (val_type == 'cpus') {
         try {
             return Math.min( obj, params.max_cpus as int )
         } catch (all) {

--- a/nextflow.config
+++ b/nextflow.config
@@ -247,7 +247,7 @@ includeConfig 'conf/modules.config'
 
 // Function to ensure that resource requirements don't go beyond
 // a maximum limit
-def check_max(obj, String type) {
+def check_max(obj, type) {
     if (type == 'memory') {
         try {
             if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)

--- a/nextflow.config
+++ b/nextflow.config
@@ -247,8 +247,8 @@ includeConfig 'conf/modules.config'
 
 // Function to ensure that resource requirements don't go beyond
 // a maximum limit
-def check_max(obj, val_type) {
-    if (val_type == 'memory') {
+def check_max(obj, String type) {
+    if (type == 'memory') {
         try {
             if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
                 return params.max_memory as nextflow.util.MemoryUnit
@@ -258,7 +258,7 @@ def check_max(obj, val_type) {
             println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
             return obj
         }
-    } else if (val_type == 'time') {
+    } else if (type == 'time') {
         try {
             if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
                 return params.max_time as nextflow.util.Duration
@@ -268,7 +268,7 @@ def check_max(obj, val_type) {
             println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
             return obj
         }
-    } else if (val_type == 'cpus') {
+    } else if (type == 'cpus') {
         try {
             return Math.min( obj, params.max_cpus as int )
         } catch (all) {

--- a/nf-test.config
+++ b/nf-test.config
@@ -15,7 +15,7 @@ config {
     profile "test"
 
     // list of filenames or patterns that should be trigger a full test run
-    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore'
+    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore', '.github/workflows/nf-test.yml'
 
     // load the necessary plugins
     plugins {

--- a/tests/data/merged_detailed_summary.tsv
+++ b/tests/data/merged_detailed_summary.tsv
@@ -1,36 +1,36 @@
 Isolate ID	Data	Data Type	Predicted Phenotype	CGE Predicted Phenotype	%Identity	%Overlap	HSP Length/Total Length	Contig	Start	End	Accession
 GCF_000196035_B	ST35 (listeria_2)	MLST									
 GCF_000196035_B	None	Plasmid									
-GCF_000196035_B	fosX	Resistance	fosfomycin	Fosfomycin	100.0	100.0	402/402	NC_003210.1	1765900.0	1765499.0	AL591981
+GCF_000196035_B	fosX	Resistance	fosfomycin	Fosfomycin	100.0	100.0	402/402	NC_003210.1	1765900	1765499	AL591981
+B2	ST678 (ecoli_achtman_4)	MLST									
+B2	IncQ1	Plasmid			100.0	66.4572864321608	529/796	JRKE01000065.1	3899	4427	M28829
+B2	aph(3'')-Ib	Resistance	streptomycin	Streptomycin	100.0	100.0	804/804	JRKE01000065.1	1684	881	AF321551
+B2	aph(6)-Id	Resistance	kanamycin	Streptomycin	100.0	100.0	837/837	JRKE01000065.1	881	45	M28829
+B2	blaCTX-M-15	Resistance	ampicillin, ceftriaxone	Amoxicillin, Ampicillin, Aztreonam, Cefepime, Cefotaxime, Ceftazidime, Ceftriaxone, Piperacillin, Ticarcillin	100.0	100.0	876/876	JRKE01000059.1	5502	6377	AY044436
+B2	blaTEM-1B	Resistance	ampicillin	Amoxicillin, Ampicillin, Cephalothin, Piperacillin, Ticarcillin	99.884	100.0	861/861	JRKE01000059.1	2680	1820	AY458016
+B2	dfrA7	Resistance	trimethoprim	Trimethoprim	100.0	100.0	474/474	JRKE01000132.1	1841	1368	AB161450
+B2	gyrA (S83A)	Resistance	ciprofloxacin I/R, nalidixic acid	Nalidixic acid,Ciprofloxacin	99.277	100.0	2628/2628	JRKE01000028.1	10028	12655	
+B2	sul1	Resistance	sulfisoxazole	Sulfamethoxazole	100.0	91.90821256038647	761/828	JRKE01000132.1	797	37	AY522923
+B2	sul2	Resistance	sulfisoxazole	Sulfamethoxazole	100.0	100.0	816/816	JRKE01000065.1	2560	1745	HQ840942
+B2	tet(A)	Resistance	tetracycline	Doxycycline, Tetracycline	100.0	100.0	1200/1200	JRKE01000131.1	1882	3081	AJ517790
+A_1_	ST66 (salmonella)	MLST									
+A_1_	IncFIB(K)	Plasmid			98.929	100.0	560/560	AY509004.1	118238	117679	JN233704
+A_1_	IncFIB(S)	Plasmid			98.756	100.0	643/643	AY509003.1	15798	16440	FN432031
+A_1_	IncFII(S)	Plasmid			99.618	100.0	262/262	AY509003.1	24607	24346	CP000858
+A_1_	CmlA7	Resistance	unknown[CmlA7_1_JQ639792]	Chloramphenicol	99.772	100.0	1314/1314	AY509004.1	41920	40607	JQ639792
+A_1_	aadA1	Resistance	streptomycin	Spectinomycin, Streptomycin	100.0	100.0	792/792	AY509004.1	40514	39723	JQ414041
+A_1_	aadA2	Resistance	streptomycin	Spectinomycin, Streptomycin	100.0	100.0	792/792	AY509004.1	25483	26274	JQ364967
+A_1_	aadA2	Resistance	streptomycin	Spectinomycin, Streptomycin	99.875	97.92429792429792	802/819	AY509004.1	42929	42128	NC_010870
+A_1_	aph(3'')-Ib	Resistance	streptomycin	Streptomycin	100.0	84.5771144278607	680/804	AY509004.1	51230	51909	AF024602
+A_1_	aph(3')-Ia	Resistance	kanamycin	Neomycin, Kanamycin, Lividomycin, Paromomycin, Ribostamycin	100.0	100.0	816/816	AY509004.1	21952	21137	V00359
+A_1_	blaCMY-2	Resistance	ampicillin, amoxicillin/clavulanic acid, cefoxitin, ceftriaxone	Amoxicillin, Amoxicillin+Clavulanic acid, Ampicillin, Ampicillin+Clavulanic acid, Cefotaxime, Cefoxitin, Ceftazidime, Piperacillin, Piperacillin+Tazobactam, Ticarcillin, Ticarcillin+Clavulanic acid	100.0	100.0	1146/1146	AY509004.1	70050	71195	X91840
+A_1_	blaTEM-1B	Resistance	ampicillin	Amoxicillin, Ampicillin, Cephalothin, Piperacillin, Ticarcillin	99.884	100.11614401858304	862/861	AY509004.1	14817	15678	AY458016
+A_1_	dfrA12	Resistance	trimethoprim	Trimethoprim	100.0	100.0	498/498	AY509004.1	24578	25075	AM040708
+A_1_	gyrA (D87N)	Resistance	ciprofloxacin I/R, nalidixic acid	Nalidixic acid,Ciprofloxacin	98.749	100.0	2637/2637	AE017220.1	2390630	2387994	
+A_1_	gyrA (S83F)	Resistance	ciprofloxacin I/R, nalidixic acid	Nalidixic acid,Ciprofloxacin	98.749	100.0	2637/2637	AE017220.1	2390630	2387994	
+A_1_	sul1	Resistance	sulfisoxazole	Sulfamethoxazole	100.0	100.0	840/840	AY509004.1	26779	27618	U12338
+A_1_	sul3	Resistance	sulfisoxazole	Sulfamethoxazole	100.0	100.0	792/792	AY509004.1	37250	38041	AJ459418
+A_1_	tet(A)	Resistance	tetracycline	Doxycycline, Tetracycline	100.0	100.0	1200/1200	AY509004.1	3713	2514	AJ517790
 B2_GCF_000196035	ST35 (listeria_2)	MLST									
 B2_GCF_000196035	None	Plasmid									
-B2_GCF_000196035	fosX	Resistance	fosfomycin	Fosfomycin	100.0	100.0	402/402	NC_003210.1	1765900.0	1765499.0	AL591981
-B2	ST678 (ecoli_achtman_4)	MLST									
-B2	IncQ1	Plasmid			100.0	66.46	529/796	JRKE01000065.1	3899.0	4427.0	M28829
-B2	aph(3'')-Ib	Resistance	streptomycin	Streptomycin	100.0	100.0	804/804	JRKE01000065.1	1684.0	881.0	AF321551
-B2	aph(6)-Id	Resistance	kanamycin	Streptomycin	100.0	100.0	837/837	JRKE01000065.1	881.0	45.0	M28829
-B2	blaCTX-M-15	Resistance	ampicillin, ceftriaxone	Amoxicillin, Ampicillin, Aztreonam, Cefepime, Cefotaxime, Ceftazidime, Ceftriaxone, Piperacillin, Ticarcillin	100.0	100.0	876/876	JRKE01000059.1	5502.0	6377.0	AY044436
-B2	blaTEM-1B	Resistance	ampicillin	Amoxicillin, Ampicillin, Cephalothin, Piperacillin, Ticarcillin	99.88	100.0	861/861	JRKE01000059.1	2680.0	1820.0	AY458016
-B2	dfrA7	Resistance	trimethoprim	Trimethoprim	100.0	100.0	474/474	JRKE01000132.1	1841.0	1368.0	AB161450
-B2	gyrA (S83A)	Resistance	ciprofloxacin I/R, nalidixic acid	Nalidixic acid,Ciprofloxacin	99.28	100.0	2628/2628	JRKE01000028.1	10028.0	12655.0	
-B2	sul1	Resistance	sulfisoxazole	Sulfamethoxazole	100.0	91.91	761/828	JRKE01000132.1	797.0	37.0	AY522923
-B2	sul2	Resistance	sulfisoxazole	Sulfamethoxazole	100.0	100.0	816/816	JRKE01000065.1	2560.0	1745.0	HQ840942
-B2	tet(A)	Resistance	tetracycline	Doxycycline, Tetracycline	100.0	100.0	1200/1200	JRKE01000131.1	1882.0	3081.0	AJ517790
-A_1_	ST66 (salmonella)	MLST									
-A_1_	IncFIB(K)	Plasmid			98.93	100.0	560/560	AY509004.1	118238.0	117679.0	JN233704
-A_1_	IncFIB(S)	Plasmid			98.76	100.0	643/643	AY509003.1	15798.0	16440.0	FN432031
-A_1_	IncFII(S)	Plasmid			99.62	100.0	262/262	AY509003.1	24607.0	24346.0	CP000858
-A_1_	CmlA7	Resistance	unknown[CmlA7_1_JQ639792]	Chloramphenicol	99.77	100.0	1314/1314	AY509004.1	41920.0	40607.0	JQ639792
-A_1_	aadA1	Resistance	streptomycin	Spectinomycin, Streptomycin	100.0	100.0	792/792	AY509004.1	40514.0	39723.0	JQ414041
-A_1_	aadA2	Resistance	streptomycin	Spectinomycin, Streptomycin	100.0	100.0	792/792	AY509004.1	25483.0	26274.0	JQ364967
-A_1_	aadA2	Resistance	streptomycin	Spectinomycin, Streptomycin	99.88	97.92	802/819	AY509004.1	42929.0	42128.0	NC_010870
-A_1_	aph(3'')-Ib	Resistance	streptomycin	Streptomycin	100.0	84.58	680/804	AY509004.1	51230.0	51909.0	AF024602
-A_1_	aph(3')-Ia	Resistance	kanamycin	Neomycin, Kanamycin, Lividomycin, Paromomycin, Ribostamycin	100.0	100.0	816/816	AY509004.1	21952.0	21137.0	V00359
-A_1_	blaCMY-2	Resistance	ampicillin, amoxicillin/clavulanic acid, cefoxitin, ceftriaxone	Amoxicillin, Amoxicillin+Clavulanic acid, Ampicillin, Ampicillin+Clavulanic acid, Cefotaxime, Cefoxitin, Ceftazidime, Piperacillin, Piperacillin+Tazobactam, Ticarcillin, Ticarcillin+Clavulanic acid	100.0	100.0	1146/1146	AY509004.1	70050.0	71195.0	X91840
-A_1_	blaTEM-1B	Resistance	ampicillin	Amoxicillin, Ampicillin, Cephalothin, Piperacillin, Ticarcillin	99.88	100.12	862/861	AY509004.1	14817.0	15678.0	AY458016
-A_1_	dfrA12	Resistance	trimethoprim	Trimethoprim	100.0	100.0	498/498	AY509004.1	24578.0	25075.0	AM040708
-A_1_	gyrA (D87N)	Resistance	ciprofloxacin I/R, nalidixic acid	Nalidixic acid,Ciprofloxacin	98.75	100.0	2637/2637	AE017220.1	2390630.0	2387994.0	
-A_1_	gyrA (S83F)	Resistance	ciprofloxacin I/R, nalidixic acid	Nalidixic acid,Ciprofloxacin	98.75	100.0	2637/2637	AE017220.1	2390630.0	2387994.0	
-A_1_	sul1	Resistance	sulfisoxazole	Sulfamethoxazole	100.0	100.0	840/840	AY509004.1	26779.0	27618.0	U12338
-A_1_	sul3	Resistance	sulfisoxazole	Sulfamethoxazole	100.0	100.0	792/792	AY509004.1	37250.0	38041.0	AJ459418
-A_1_	tet(A)	Resistance	tetracycline	Doxycycline, Tetracycline	100.0	100.0	1200/1200	AY509004.1	3713.0	2514.0	AJ517790
+B2_GCF_000196035	fosX	Resistance	fosfomycin	Fosfomycin	100.0	100.0	402/402	NC_003210.1	1765900	1765499	AL591981

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -7,7 +7,7 @@
                     "yaml": "6.0"
                 },
                 "STARAMR_SEARCH": {
-                    "staramr": "0.12.1"
+                    "staramr": "0.12.2"
                 },
                 "Workflow": {
                     "phac-nml/staramrnf": "0.3.2"
@@ -61,24 +61,24 @@
                 "staramr/GCF_000196035_B_results/GCF_000196035_B_summary.staramr.tsv"
             ],
             [
-                "A_1__detailed_summary.staramr.tsv:md5,baa57e24f7fa461be86b3a9c25e94f44",
+                "A_1__detailed_summary.staramr.tsv:md5,cb909766c34cc4d608a55b2dab4d5527",
                 "A_1__mlst.staramr.tsv:md5,175670a7c8fc2fd953a81ac99b1a6e6b",
                 "A_1__plasmidfinder.staramr.tsv:md5,d2d72406cca5e1f166dcb24d2507537d",
                 "A_1__pointfinder.staramr.tsv:md5,5f3bbf121a668a170357af254c117e15",
                 "A_1__resfinder.staramr.tsv:md5,77de8d59a2e283a30da61eca274e8e09",
                 "A_1__summary.staramr.tsv:md5,959571505b0ae540b4179f204d1e6dd6",
-                "B2_GCF_000196035_detailed_summary.staramr.tsv:md5,ae803c270d4fb799903c417aadd1f992",
+                "B2_GCF_000196035_detailed_summary.staramr.tsv:md5,997513a5641b4bf3d0f0bed3251dc12a",
                 "B2_GCF_000196035_mlst.staramr.tsv:md5,cc77e22bfc4b91aad5c1a82e79b30986",
                 "B2_GCF_000196035_plasmidfinder.staramr.tsv:md5,06f38f23d6be0fb32bf66d31a517d78c",
                 "B2_GCF_000196035_resfinder.staramr.tsv:md5,eddb40d436128595e7ac5c91fcb2bda0",
                 "B2_GCF_000196035_summary.staramr.tsv:md5,b818d2eead6dfd127aa5644bc1ac64bc",
-                "B2_detailed_summary.staramr.tsv:md5,43e7bb9feef07b007628702c6f126a8d",
+                "B2_detailed_summary.staramr.tsv:md5,4afce7dd1637d3d5076b7123d8a30ca0",
                 "B2_mlst.staramr.tsv:md5,bbe1213eb4f9d2b044ee26ea17df8826",
                 "B2_plasmidfinder.staramr.tsv:md5,02503f0dca5bf6f33215215173d0c910",
                 "B2_pointfinder.staramr.tsv:md5,9baf996c113fcc9bbf007ef4085d5228",
                 "B2_resfinder.staramr.tsv:md5,dc5c476083c04ea581bad0d149168964",
                 "B2_summary.staramr.tsv:md5,f5e5840fe7630bd2409a3506a8d2e064",
-                "GCF_000196035_B_detailed_summary.staramr.tsv:md5,329cdaa668b7d7c68edfa9a54515762f",
+                "GCF_000196035_B_detailed_summary.staramr.tsv:md5,75b59dbf3eadd4b1d8892057e7cc6ae0",
                 "GCF_000196035_B_mlst.staramr.tsv:md5,ee29f2af41c7a78dad1549b6707b15d1",
                 "GCF_000196035_B_plasmidfinder.staramr.tsv:md5,06f38f23d6be0fb32bf66d31a517d78c",
                 "GCF_000196035_B_resfinder.staramr.tsv:md5,34c9513efc4c7db35b43d435b9d28f28",
@@ -89,6 +89,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.6"
         },
-        "timestamp": "2026-03-12T20:11:46.12416686"
+        "timestamp": "2026-05-01T14:48:06.909540879"
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -10,7 +10,7 @@
                     "staramr": "0.12.2"
                 },
                 "Workflow": {
-                    "phac-nml/staramrnf": "0.3.2"
+                    "phac-nml/staramrnf": "0.3.3"
                 }
             },
             [
@@ -89,6 +89,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.6"
         },
-        "timestamp": "2026-05-01T14:48:06.909540879"
+        "timestamp": "2026-05-04T13:25:11.110240112"
     }
 }

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                     "yaml": "6.0"
                 },
                 "STARAMR_SEARCH": {
-                    "staramr": "0.12.1"
+                    "staramr": "0.12.2"
                 },
                 "Workflow": {
                     "phac-nml/staramrnf": "0.3.2"
@@ -18,6 +18,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.6"
         },
-        "timestamp": "2026-03-12T20:12:21.154731704"
+        "timestamp": "2026-05-01T14:48:50.096576717"
     }
 }

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -10,7 +10,7 @@
                     "staramr": "0.12.2"
                 },
                 "Workflow": {
-                    "phac-nml/staramrnf": "0.3.2"
+                    "phac-nml/staramrnf": "0.3.3"
                 }
             }
         ],
@@ -18,6 +18,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.6"
         },
-        "timestamp": "2026-05-01T14:48:50.096576717"
+        "timestamp": "2026-05-04T13:25:40.667069187"
     }
 }


### PR DESCRIPTION
## [0.3.3] - 2026-05-06

### `Updated`

- Set nextflow version 25.10.4 to replace 'latest-everything' to confirm compatibility with next IRIDA-Next nextflow version in `.github/workflows` for nf-test. [PR #39](https://github.com/phac-nml/staramrnf/pull/39)
- starAMR version updated to 0.12.2. [PR #40](https://github.com/phac-nml/staramrnf/pull/40)
- 
[0.3.3]: https://github.com/phac-nml/staramrnf/releases/tag/0.3.3
