### PR TITLE
0.4.1 patch fix: campylobactera pointfinder typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.1] - 2026-07-15
+
+### Fixed
+
+- Fix the typo in "autodetection" of Campylobacter pointfinder database. [PR #45](https://github.com/phac-nml/staramrnf/pull/45)
+
 ## [0.4.0] - 2026-07-10
 
 ### `Added`
@@ -77,3 +84,4 @@ staramrnf follows the `nf-core` pipeline file structure and used the nf-core [te
 [0.3.2]: https://github.com/phac-nml/staramrnf/releases/tag/0.3.2
 [0.3.3]: https://github.com/phac-nml/staramrnf/releases/tag/0.3.3
 [0.4.0]: https://github.com/phac-nml/staramrnf/releases/tag/0.4.0
+[0.4.1]: https://github.com/phac-nml/staramrnf/releases/tag/0.4.1

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -37,7 +37,7 @@ process {
                                     'enterococcus_faecium', 'escherichia_coli', 'helicobacter_pylori']
 
         // Convert the species name to a Pointfinder database-style name:
-        def species_code = "[sS]almonella|[cC]amplyobacter|[eE]nterococcus.faecalis|[eE]nterococcus.faecium|[eE]scherichia.coli|[hH]elicobacter.pylori"
+        def species_code = "[sS]almonella|[cC]ampylobacter|[eE]nterococcus.faecalis|[eE]nterococcus.faecium|[eE]scherichia.coli|[hH]elicobacter.pylori"
         def convert = {String species_name -> species_name.trim().toLowerCase().replaceAll(" ", "_").find(species_code)}
 
         // Genus specific parameter selection

--- a/nextflow.config
+++ b/nextflow.config
@@ -276,7 +276,7 @@ manifest {
     description     = """StarAMR: Scans genome contigs against the ResFinder, PlasmidFinder, and PointFinder databases."""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=24.10.3'
-    version         = '0.4.0'
+    version         = '0.4.1'
     doi             = ''
     defaultBranch   = 'main'
 }

--- a/tests/data/samplesheets/species.csv
+++ b/tests/data/samplesheets/species.csv
@@ -1,6 +1,8 @@
 sample,contigs,species
 Salmonella,https://github.com/phac-nml/staramrnf/raw/dev/tests/data/genomes/salmonella/GCA_000008105.1_ASM810v1_genomic.fna.gz,Salmonella
 Escherichaia,https://github.com/phac-nml/staramrnf/raw/dev/tests/data/genomes/ecoli/GCA_000947975.1_ASM94797v1_genomic.fna.gz,Escherichia coli
+Campylobacter,https://github.com/phac-nml/staramrnf/raw/dev/tests/data/genomes/listeria/GCF_000196035.1_ASM19603v1_genomic.fna,Campylobacter
+Shigella,https://github.com/phac-nml/staramrnf/raw/dev/tests/data/genomes/listeria/GCF_000196035.1_ASM19603v1_genomic.fna,Shigella
 Listeria,https://github.com/phac-nml/staramrnf/raw/dev/tests/data/genomes/listeria/GCF_000196035.1_ASM19603v1_genomic.fna,Listeria monocytogenes
 Salmonella_default,https://github.com/phac-nml/staramrnf/raw/dev/tests/data/genomes/salmonella/GCA_000008105.1_ASM810v1_genomic.fna.gz,
 Escherichaia_default,https://github.com/phac-nml/staramrnf/raw/dev/tests/data/genomes/ecoli/GCA_000947975.1_ASM94797v1_genomic.fna.gz,

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -10,7 +10,7 @@
                     "staramr": "0.12.3"
                 },
                 "Workflow": {
-                    "phac-nml/staramrnf": "0.4.0"
+                    "phac-nml/staramrnf": "0.4.1"
                 }
             },
             [
@@ -86,9 +86,9 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.5"
         },
-        "timestamp": "2026-07-10T09:03:16.964204687"
+        "timestamp": "2026-07-15T13:38:01.799753645"
     }
 }

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -189,7 +189,9 @@ nextflow_pipeline {
 
         // Sample Sheet:
         // 1: Salmonella (specified) -> Salmonella
-        // 2: Escherichaia (specified) -> E. coli
+        // 2: Escherichaia (specified) -> Escherichia
+        // 3: Campylobacter (specified) -> Campylobacter
+        // 4: Shigella (specified) -> Shigella (no pointfinder database)
         // 3: Listeria (specified) -> DEFAULT
         // 4: Salmonella_default (unspecified/blank/default) -> DEFAULT
         // 5: Escherichaia_default (unspecified/blank/default) -> DEFAULT
@@ -315,6 +317,21 @@ nextflow_pipeline {
             def listeria_settings = new File("$outputDir/staramr/Listeria_results/Listeria_settings.staramr.txt")
             def listeria_cmd = listeria_settings.readLines().get(0)
             assert listeria_cmd == "command_line                  = /usr/local/bin/staramr search --minimum-contig-length 300 --minimum-N50-value 10000 --minimum-contig-length 300 --unacceptable-number-contigs 1000 --pid-threshold 98 --percent-length-overlap-plasmidfinder 60 --genome-size-lower-bound 4000000 --genome-size-upper-bound 6000000 --percent-length-overlap-resfinder 60 --percent-length-overlap-pointfinder 95 --nprocs 1 -o Listeria_results Listeria.fasta"
+
+            // Campylobacter (specified)
+            assert path("$outputDir/staramr/Campylobacter_results/Campylobacter_settings.staramr.txt").exists()
+            def campy_settings = new File("$outputDir/staramr/Campylobacter_results/Campylobacter_settings.staramr.txt")
+            def campy_cmd = campy_settings.readLines().get(0)
+            assert campy_cmd == "command_line                  = /usr/local/bin/staramr search --pointfinder-organism campylobacter --minimum-contig-length 300 --minimum-N50-value 10000 --minimum-contig-length 300 --unacceptable-number-contigs 1000 --pid-threshold 98 --percent-length-overlap-plasmidfinder 60 --genome-size-lower-bound 1250000 --genome-size-upper-bound 2500000 --percent-length-overlap-resfinder 52 --percent-length-overlap-pointfinder 58 --nprocs 1 -o Campylobacter_results Campylobacter.fasta"
+
+            // Shigella (specified)
+            // Modified genome size and % overlap with resfinder and pointfinder
+            // pointfinder_database should not be selected
+            assert path("$outputDir/staramr/Shigella_results/Shigella_settings.staramr.txt").exists()
+            def shigella_settings = new File("$outputDir/staramr/Shigella_results/Shigella_settings.staramr.txt")
+            def shigella_cmd = shigella_settings.readLines().get(0)
+            assert shigella_cmd == "command_line                  = /usr/local/bin/staramr search --minimum-contig-length 300 --minimum-N50-value 10000 --minimum-contig-length 300 --unacceptable-number-contigs 1000 --pid-threshold 98 --percent-length-overlap-plasmidfinder 60 --genome-size-lower-bound 4000000 --genome-size-upper-bound 6700000 --percent-length-overlap-resfinder 52 --percent-length-overlap-pointfinder 95 --nprocs 1 -o Shigella_results Shigella.fasta"
+
         }
     }
 }


### PR DESCRIPTION
## [0.4.1] - 2026-07-15

### Fixed

- Fix the typo in "autodetection" of Campylobacter pointfinder database. [PR #45](https://github.com/phac-nml/staramrnf/pull/45)

[0.4.1]: https://github.com/phac-nml/staramrnf/releases/tag/0.4.1